### PR TITLE
Don't ignore nil devices in plugin fingerprint

### DIFF
--- a/client/devicemanager/instance.go
+++ b/client/devicemanager/instance.go
@@ -413,11 +413,6 @@ func (i *instanceManager) handleFingerprintError() {
 // handleFingerprint stores the new devices and triggers the fingerprint output
 // channel. An error is returned if the passed devices don't pass validation.
 func (i *instanceManager) handleFingerprint(f *device.FingerprintResponse) error {
-	// If no devices are returned then there is nothing to do.
-	if f.Devices == nil {
-		return nil
-	}
-
 	// Validate the received devices
 	var validationErr multierror.Error
 	for i, d := range f.Devices {


### PR DESCRIPTION
Even if a plugin sends back an empty `[]*device.DeviceGroup`, it's transformed to `nil` during the RPC between nomad and the plugin. This conditional block prevented the manager to trigger the logic for "first fingerprint received". This adds a lot of latency when starting nomad.

Our custom device plugin is returning an empty `FingerprintResponse.Devices` slice very often. Our temporary fix is to send a `][]*DeviceGroup` with a "dummy" `DeviceGroup` if the slice is empty.

Not triggering the "first fingerprint received" adds 50s to nomad's startup time (because of the batch fingerprint timeout of 50s). In turn, this made our node exceed its hearbeat grace period with our leader when restarting it, revoking all vault tokens for its allocations, causing a restart of all our allocations because their tokens couldn't be renewed.

Removing the logic for `f.Devices == nil` does not appear to affect the functionality of the function.